### PR TITLE
fix: tolerate invalid browser storage

### DIFF
--- a/vue-toutiao/package.json
+++ b/vue-toutiao/package.json
@@ -12,6 +12,8 @@
     "build": "node build/build.js",
     "dll": "node node_modules/webpack/bin/webpack.js -p --progress --config build/webpack.dll.conf.js",
     "test:ensure-dll": "node build/ensure-dll.test.js && node build/dll-command.test.js",
+    "test:storage": "node src/utils/storage-value.test.js",
+    "test": "npm run test:ensure-dll && npm run test:storage",
     "analyze": "cross-env analyz_npm_config_report=true npm run build",
     "analyz": "npm run analyze"
   },

--- a/vue-toutiao/src/utils/storage-value.js
+++ b/vue-toutiao/src/utils/storage-value.js
@@ -1,0 +1,14 @@
+'use strict'
+
+function getStoredValue(storage, key) {
+    if (!key) return null
+
+    try {
+        const value = storage.getItem(key)
+        return value === null ? null : JSON.parse(value)
+    } catch (error) {
+        return null
+    }
+}
+
+module.exports = getStoredValue

--- a/vue-toutiao/src/utils/storage-value.test.js
+++ b/vue-toutiao/src/utils/storage-value.test.js
@@ -1,0 +1,20 @@
+'use strict'
+
+const assert = require('assert')
+const getStoredValue = require('./storage-value')
+
+function storageWith(value) {
+  return {
+    getItem() {
+      return value
+    }
+  }
+}
+
+assert.deepStrictEqual(getStoredValue(storageWith('["vue","webpack"]'), 'history'), ['vue', 'webpack'])
+assert.strictEqual(getStoredValue(storageWith(null), 'missing'), null)
+assert.strictEqual(getStoredValue(storageWith('{not-json'), 'broken'), null)
+assert.strictEqual(getStoredValue(storageWith('"value"'), ''), null)
+assert.strictEqual(getStoredValue({ getItem() { throw new Error('blocked') } }, 'private'), null)
+
+console.log('storage value tests passed')

--- a/vue-toutiao/src/utils/storage.js
+++ b/vue-toutiao/src/utils/storage.js
@@ -1,5 +1,6 @@
 const ls = window.localStorage;
 const ss = window.sessionStorage;
+const getStoredValue = require('./storage-value');
 
 export const Cookie = {
     get (key) {
@@ -42,8 +43,7 @@ export const Cookie = {
 
 export const Local = {
     get(key) {
-        if (key) return JSON.parse(ls.getItem(key))
-        return null
+        return getStoredValue(ls, key)
     },
     set(key, val) {
         const setting = arguments[0]
@@ -66,8 +66,7 @@ export const Local = {
 
 export const Session = {
     get(key) {
-        if (key) return JSON.parse(ss.getItem(key))
-        return null
+        return getStoredValue(ss, key)
     },
     set(key, val) {
         const setting = arguments[0]


### PR DESCRIPTION
## What changed

- route local and session storage reads through a safe JSON parser
- return `null` for missing, malformed, or inaccessible browser storage values
- add regression coverage and a top-level test command

## Why

The recently added search history is read during Vuex store initialization. A malformed `localStorage` value currently throws from `JSON.parse` and can prevent the application from starting. The new parser preserves valid values and safely falls back when persisted data cannot be read.

## Validation

- `npm test`
- `NODE_OPTIONS=--openssl-legacy-provider npm run build`
- `git diff --check`