### PR TITLE
fix: avoid article reload when leaving route

### DIFF
--- a/docs/superpowers/specs/2026-08-14-article-route-watch-design.md
+++ b/docs/superpowers/specs/2026-08-14-article-route-watch-design.md
@@ -1,0 +1,35 @@
+# Article Route Watch Fix
+
+## Problem
+
+The article view watches the entire `$route` object. Leaving an article for an unrelated page changes `$route`, so the component starts another article request with no article ID and shows the global loading layer during navigation. This matches issue #6.
+
+## Design
+
+Watch `$route.params.id` instead of the entire route and pass ID changes through a small route-change helper. The helper calls the supplied loader only when the next ID is present and differs from the previous ID.
+
+This preserves direct navigation from one article ID to another while making navigation away from the article a no-op. The component's initial `created` load remains unchanged. Loading cleanup moves to `finally` so a failed request cannot leave the loading layer visible.
+
+## Error Handling
+
+- Missing next ID: resolve without calling the loader.
+- Unchanged ID: resolve without calling the loader.
+- Loader rejection: propagate the error after the component hides the loading layer.
+
+## Tests
+
+1. A missing next ID does not call the loader.
+2. An unchanged ID does not call the loader.
+3. A changed, valid ID calls the loader exactly once with that ID.
+4. Run the complete unit suite and production build.
+
+## Implementation Steps
+
+1. Add failing tests for the route-change helper.
+2. Add the minimal helper implementation.
+3. Update the article watcher to use the helper and `finally` cleanup.
+4. Run the focused tests, full test suite, diff checks, and production build.
+
+## Scope
+
+No router configuration, API shape, UI layout, or unrelated route behavior changes.

--- a/vue-toutiao/package.json
+++ b/vue-toutiao/package.json
@@ -13,7 +13,8 @@
     "dll": "node node_modules/webpack/bin/webpack.js -p --progress --config build/webpack.dll.conf.js",
     "test:ensure-dll": "node build/ensure-dll.test.js && node build/dll-command.test.js",
     "test:storage": "node src/utils/storage-value.test.js",
-    "test": "npm run test:ensure-dll && npm run test:storage",
+    "test:article-route": "node src/views/Article/load-article-when-changed.test.js",
+    "test": "npm run test:ensure-dll && npm run test:storage && npm run test:article-route",
     "analyze": "cross-env analyz_npm_config_report=true npm run build",
     "analyz": "npm run analyze"
   },

--- a/vue-toutiao/src/views/Article/index.vue
+++ b/vue-toutiao/src/views/Article/index.vue
@@ -30,6 +30,8 @@
 </template>
 <script>
     import { mapGetters } from 'vuex'
+    const loadArticleWhenChanged = require('./load-article-when-changed')
+
     export default {
         async created () {
             this.$showLoading()
@@ -47,10 +49,14 @@
             ])
         },
         watch: {
-            async $route () {
-                this.$showLoading()
-                await this.$store.dispatch('getArticle', {id: this.$route.params.id})
-                this.$hideLoading()
+            async '$route.params.id' (nextId, previousId) {
+                await loadArticleWhenChanged(
+                    nextId,
+                    previousId,
+                    id => this.$store.dispatch('getArticle', {id}),
+                    this.$showLoading,
+                    this.$hideLoading
+                )
             }
         }
     }

--- a/vue-toutiao/src/views/Article/load-article-when-changed.js
+++ b/vue-toutiao/src/views/Article/load-article-when-changed.js
@@ -1,0 +1,16 @@
+'use strict'
+
+async function loadArticleWhenChanged(nextId, previousId, loadArticle, showLoading, hideLoading) {
+  if (nextId === undefined || nextId === null || nextId === '' || nextId === previousId) {
+    return
+  }
+
+  showLoading()
+  try {
+    await loadArticle(nextId)
+  } finally {
+    hideLoading()
+  }
+}
+
+module.exports = loadArticleWhenChanged

--- a/vue-toutiao/src/views/Article/load-article-when-changed.test.js
+++ b/vue-toutiao/src/views/Article/load-article-when-changed.test.js
@@ -1,0 +1,47 @@
+'use strict'
+
+const assert = require('assert')
+const loadArticleWhenChanged = require('./load-article-when-changed')
+
+async function run() {
+  const events = []
+  const loadArticle = id => {
+    events.push(`load:${id}`)
+    return Promise.resolve()
+  }
+  const showLoading = () => events.push('show')
+  const hideLoading = () => events.push('hide')
+
+  await loadArticleWhenChanged(undefined, '41', loadArticle, showLoading, hideLoading)
+  assert.deepStrictEqual(events, [], 'leaving the article route must not load without an ID')
+
+  await loadArticleWhenChanged('41', '41', loadArticle, showLoading, hideLoading)
+  assert.deepStrictEqual(events, [], 'an unchanged article ID must not reload')
+
+  await loadArticleWhenChanged('42', '41', loadArticle, showLoading, hideLoading)
+  assert.deepStrictEqual(events, ['show', 'load:42', 'hide'], 'a changed article ID must load once between loading callbacks')
+
+  const requestError = new Error('request failed')
+  events.length = 0
+  await assert.rejects(
+    loadArticleWhenChanged(
+      '43',
+      '42',
+      () => {
+        events.push('load:43')
+        return Promise.reject(requestError)
+      },
+      showLoading,
+      hideLoading
+    ),
+    error => error === requestError
+  )
+  assert.deepStrictEqual(events, ['show', 'load:43', 'hide'], 'a failed request must still hide loading')
+
+  console.log('article route change tests passed')
+}
+
+run().catch(error => {
+  console.error(error)
+  process.exitCode = 1
+})


### PR DESCRIPTION
## What changed

- watch the article route ID instead of the entire route object
- skip requests when navigation removes the article ID or leaves it unchanged
- preserve article-to-article navigation and always hide the loading layer after a started request
- add focused regression coverage and a short design note

## Root cause

The article component watched `$route`, so every navigation—including leaving the article page—started `getArticle` with an undefined ID and displayed the global loading layer.

## Validation

- `npm test`
- `NODE_OPTIONS=--openssl-legacy-provider npm run build`
- `git diff --check`

Fixes #6