### PR TITLE
fix: restore home list scroll position

### DIFF
--- a/vue-toutiao/package.json
+++ b/vue-toutiao/package.json
@@ -14,7 +14,8 @@
     "test:ensure-dll": "node build/ensure-dll.test.js && node build/dll-command.test.js",
     "test:storage": "node src/utils/storage-value.test.js",
     "test:article-route": "node src/views/Article/load-article-when-changed.test.js",
-    "test": "npm run test:ensure-dll && npm run test:storage && npm run test:article-route",
+    "test:home-scroll": "node src/views/Home/scroll-position.test.js",
+    "test": "npm run test:ensure-dll && npm run test:storage && npm run test:article-route && npm run test:home-scroll",
     "analyze": "cross-env analyz_npm_config_report=true npm run build",
     "analyz": "npm run analyze"
   },

--- a/vue-toutiao/src/store/modules/home.js
+++ b/vue-toutiao/src/store/modules/home.js
@@ -15,6 +15,7 @@ const home = {
         })(),
         newsIndex: 0,
         newsPrevIndex: 0,
+        scrollPositions: [],
         newsLoading: false,
         end: false
     },
@@ -46,6 +47,9 @@ const home = {
         }
     },
     mutations:{
+        SETHOMESCROLLPOSITIONS (state, positions) {
+            state.scrollPositions = positions
+        },
         ADDHOMETAG (state, news) {
             if (state.newsList.every( tag => tag.title !== news.title)) {
                 state.newsList.push(news)

--- a/vue-toutiao/src/views/Home/index.vue
+++ b/vue-toutiao/src/views/Home/index.vue
@@ -68,6 +68,11 @@
     import { swiper, swiperSlide } from 'vue-awesome-swiper'
     import { mapGetters } from 'vuex'
     import TopBar from './topbar/index.vue'
+    const {
+        captureScrollPositions,
+        restoreScrollPositions
+    } = require('./scroll-position')
+
     export default {
         components: {
             swiper, 
@@ -76,6 +81,29 @@
         },
         created () {
             this.$store.dispatch('getHomeList', this.newsList[this.homeNewsIndex])
+        },
+        beforeRouteEnter (to, from, next) {
+            next(vm => {
+                if (from.name !== '文章') {
+                    vm.$store.commit('SETHOMESCROLLPOSITIONS', [])
+                    return
+                }
+
+                vm.$nextTick(() => {
+                    restoreScrollPositions(
+                        vm.$el.querySelectorAll('.swiper-box'),
+                        vm.$store.state.home.scrollPositions
+                    )
+                    vm.$store.commit('SETHOMESCROLLPOSITIONS', [])
+                })
+            })
+        },
+        beforeRouteLeave (to, from, next) {
+            const positions = to.name === '文章'
+                ? captureScrollPositions(this.$el.querySelectorAll('.swiper-box'))
+                : []
+            this.$store.commit('SETHOMESCROLLPOSITIONS', positions)
+            next()
         },
         methods: {
             async end () {

--- a/vue-toutiao/src/views/Home/scroll-position.js
+++ b/vue-toutiao/src/views/Home/scroll-position.js
@@ -1,0 +1,18 @@
+'use strict'
+
+function captureScrollPositions(containers) {
+  return Array.prototype.map.call(containers, container => container.scrollTop)
+}
+
+function restoreScrollPositions(containers, positions) {
+  Array.prototype.forEach.call(containers, (container, index) => {
+    if (typeof positions[index] === 'number') {
+      container.scrollTop = positions[index]
+    }
+  })
+}
+
+module.exports = {
+  captureScrollPositions,
+  restoreScrollPositions
+}

--- a/vue-toutiao/src/views/Home/scroll-position.test.js
+++ b/vue-toutiao/src/views/Home/scroll-position.test.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const assert = require('assert')
+const {
+  captureScrollPositions,
+  restoreScrollPositions
+} = require('./scroll-position')
+
+function run() {
+  const firstContainer = { scrollTop: 120 }
+  const secondContainer = { scrollTop: 480 }
+  const containers = {
+    0: firstContainer,
+    1: secondContainer,
+    length: 2
+  }
+
+  assert.deepStrictEqual(
+    captureScrollPositions(containers),
+    [120, 480],
+    'each channel scroll position must be captured by index'
+  )
+
+  firstContainer.scrollTop = 0
+  secondContainer.scrollTop = 0
+  restoreScrollPositions(containers, [120, 480])
+
+  assert.deepStrictEqual(
+    [firstContainer.scrollTop, secondContainer.scrollTop],
+    [120, 480],
+    'each channel scroll position must be restored by index'
+  )
+
+  const untouched = { scrollTop: 75 }
+  restoreScrollPositions({ 0: untouched, length: 1 }, [])
+  assert.strictEqual(
+    untouched.scrollTop,
+    75,
+    'a missing saved position must not reset the current scroll position'
+  )
+
+  console.log('home scroll position tests passed')
+}
+
+run()


### PR DESCRIPTION
## What changed

- capture the scroll offsets for every Home news channel before opening an article
- restore those offsets after returning from the article route
- clear saved offsets after use so unrelated navigation does not restore stale positions
- add focused regression coverage for array-like DOM collections and missing saved positions

## Root cause

The Home feed scrolls inside `.swiper-box` elements rather than the browser window. Vue Router's window-level scroll restoration therefore cannot recover the list position after the route transition.

## Validation

- `npm test`
- `NODE_OPTIONS=--openssl-legacy-provider npm run build`
- `git -c core.whitespace=cr-at-eol diff --check`

Fixes #2