### PR TITLE
fix: clear loading state after request errors

### DIFF
--- a/docs/superpowers/plans/2026-08-17-loading-state-errors.md
+++ b/docs/superpowers/plans/2026-08-17-loading-state-errors.md
@@ -1,0 +1,112 @@
+# Request Failure Loading-State Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ensure every list-related Vuex action leaves its loading UI when the external API rejects while preserving the original error.
+
+**Architecture:** Keep each existing action and success path intact. Add a focused Node regression test that loads the real Vuex modules with only the external request and browser-only dependencies replaced, then add the matching loading-flag reset to each rejection branch.
+
+**Tech Stack:** Vue 2, Vuex 3, Babel 6 (`babel-register`), Node `assert`, npm scripts
+
+## Global Constraints
+
+- Preserve the original rejection value.
+- Do not change successful response behavior, API endpoints, pagination rules, visual layout, dependencies, or unrelated store state.
+- All GitHub remote operations must use the installed GitHub plugin.
+
+---
+
+### Task 1: Add failing request-state regression coverage
+
+**Files:**
+- Create: `vue-toutiao/src/store/modules/loading-state.test.js`
+- Modify: `vue-toutiao/package.json`
+
+**Interfaces:**
+- Consumes: Existing Vuex action signatures `(context, params) => Promise` from Home, Search, Video, Headline, and Record modules.
+- Produces: `npm run test:loading-state`, which rejects a deterministic request and asserts each module's loading flag is false afterward.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `loading-state.test.js` with a rejected request adapter, browser dependency shims, and this action matrix:
+
+```js
+const cases = [
+  ['home/getHomeList', home.actions.getHomeList, home.state, 'newsLoading', { id: 1 }],
+  ['search/getSearchList', search.actions.getSearchList, search.state, 'loading', {}],
+  ['video/getVideoList', video.actions.getVideoList, video.state, 'loading', {}],
+  ['headline/getHeadlineList', headline.actions.getHeadlineList, headline.state, 'loading', {}],
+  ['headline/addHeadline', headline.actions.addHeadline, headline.state, 'loading', {}],
+  ['record/getRecordList', record.actions.getRecordList, record.state, 'loading', { title: '我的收藏' }]
+]
+```
+
+For every case, call the real action with `{ state, commit () {} }`, assert rejection identity with `assert.rejects`, and assert `state[key] === false`.
+
+- [ ] **Step 2: Register the focused test command**
+
+Add to `package.json`:
+
+```json
+"test:loading-state": "node src/store/modules/loading-state.test.js"
+```
+
+Append `npm run test:loading-state` to the existing `test` script.
+
+- [ ] **Step 3: Run the focused test and verify RED**
+
+Run: `npm run test:loading-state`
+
+Expected: FAIL because at least `home/getHomeList` leaves `newsLoading` equal to `true` after the rejected request.
+
+### Task 2: Reset loading state in every affected failure branch
+
+**Files:**
+- Modify: `vue-toutiao/src/store/modules/home.js`
+- Modify: `vue-toutiao/src/store/modules/search.js`
+- Modify: `vue-toutiao/src/store/modules/video.js`
+- Modify: `vue-toutiao/src/store/modules/headline.js`
+- Modify: `vue-toutiao/src/store/modules/record.js`
+- Test: `vue-toutiao/src/store/modules/loading-state.test.js`
+
+**Interfaces:**
+- Consumes: Each module's existing loading state property.
+- Produces: Rejected actions that restore the property to `false` and reject with the unchanged error.
+
+- [ ] **Step 1: Add the minimal failure cleanup**
+
+Before `reject(err)` in every affected catch branch, set the same flag that the action enabled:
+
+```js
+state.loading = false
+reject(err)
+```
+
+Use `state.newsLoading = false` for `home/getHomeList`. Apply `state.loading = false` to Search, Video, both Headline actions, and Record.
+
+- [ ] **Step 2: Run the focused test and verify GREEN**
+
+Run: `npm run test:loading-state`
+
+Expected: PASS with `loading state error tests passed`.
+
+- [ ] **Step 3: Run complete verification**
+
+Run:
+
+```bash
+npm test
+NODE_OPTIONS=--openssl-legacy-provider npm run build
+git -c core.whitespace=cr-at-eol diff --check
+```
+
+Expected: all tests pass, production build completes, and the diff check reports no errors.
+
+- [ ] **Step 4: Review and commit the implementation**
+
+Review only the design, plan, test, package script, and five store modules. Commit with:
+
+```bash
+git add docs/superpowers vue-toutiao/package.json vue-toutiao/src/store/modules
+git commit -m "fix: clear loading state after request errors"
+```

--- a/docs/superpowers/specs/2026-08-17-loading-state-errors-design.md
+++ b/docs/superpowers/specs/2026-08-17-loading-state-errors-design.md
@@ -1,0 +1,29 @@
+# Request Failure Loading-State Fix
+
+## Problem
+
+The Home, Search, Video, Headline, and Record Vuex actions enable a loading flag before calling the external Mock API. Their success branches clear that flag, but their rejection branches only propagate the error. A network or API failure therefore leaves the affected page in a permanent loading state.
+
+## Design
+
+Keep the existing request and success flows unchanged. In every affected action, clear the same loading flag in the rejection branch before rejecting with the original error. This is intentionally explicit in each module so the change does not introduce a new request abstraction or alter response handling.
+
+Affected actions:
+
+- `home/getHomeList` (`newsLoading`)
+- `search/getSearchList` (`loading`)
+- `video/getVideoList` (`loading`)
+- `headline/getHeadlineList` and `headline/addHeadline` (`loading`)
+- `record/getRecordList` (`loading`)
+
+## Error Handling
+
+The original rejection value must be preserved. The fix only guarantees that the page can leave its loading UI after a failed request; it does not replace the external API, add retries, or introduce new user-facing error messages.
+
+## Tests
+
+Add a focused Node test that loads the real Vuex module actions while replacing only the external request layer with a deterministic rejected promise. For every affected action, assert both that the original error is propagated and that its loading flag is false afterward. Add the test to the existing `npm test` chain, then run the full test suite and production build.
+
+## Scope
+
+No successful response behavior, API endpoint, pagination rule, visual layout, dependency, or unrelated store state changes.

--- a/vue-toutiao/package.json
+++ b/vue-toutiao/package.json
@@ -15,7 +15,8 @@
     "test:storage": "node src/utils/storage-value.test.js",
     "test:article-route": "node src/views/Article/load-article-when-changed.test.js",
     "test:home-scroll": "node src/views/Home/scroll-position.test.js",
-    "test": "npm run test:ensure-dll && npm run test:storage && npm run test:article-route && npm run test:home-scroll",
+    "test:loading-state": "node src/store/modules/loading-state.test.js",
+    "test": "npm run test:ensure-dll && npm run test:storage && npm run test:article-route && npm run test:home-scroll && npm run test:loading-state",
     "analyze": "cross-env analyz_npm_config_report=true npm run build",
     "analyz": "npm run analyze"
   },

--- a/vue-toutiao/src/store/modules/headline.js
+++ b/vue-toutiao/src/store/modules/headline.js
@@ -23,6 +23,7 @@ const headline = {
                         commit('GETHEADLINELIST', res.data.list)
                         resolve(res.data.list)
                     }).catch( err => {
+                        state.loading = false
                         reject(err)
                     })
             })
@@ -37,6 +38,7 @@ const headline = {
                         commit('ADDHEADLINE', res.data)
                         resolve(res.data)
                     }).catch( err => {
+                        state.loading = false
                         reject(err)
                     })
             })

--- a/vue-toutiao/src/store/modules/home.js
+++ b/vue-toutiao/src/store/modules/home.js
@@ -41,6 +41,7 @@ const home = {
                         commit('GETHOMELIST', res.data.list)
                         resolve(res.data.list)
                     }).catch( err => {
+                        state.newsLoading = false
                         reject(err)
                     })
             })

--- a/vue-toutiao/src/store/modules/loading-state.test.js
+++ b/vue-toutiao/src/store/modules/loading-state.test.js
@@ -1,0 +1,96 @@
+'use strict'
+
+process.env.BABEL_ENV = 'test'
+require('babel-register')
+
+const assert = require('assert')
+const Module = require('module')
+
+const requestError = new Error('request failed')
+const failingHttp = {
+  get() {
+    return Promise.reject(requestError)
+  },
+  post() {
+    return Promise.reject(requestError)
+  }
+}
+
+const originalLoad = Module._load
+Module._load = function loadWithTestDependencies(request, parent, isMain) {
+  if (request === 'src/utils/fetch') {
+    return { __esModule: true, default: failingHttp }
+  }
+  if (request === 'utils/storage') {
+    return {
+      __esModule: true,
+      Local: {
+        get() { return null },
+        set() {}
+      }
+    }
+  }
+  if (request === 'vue') {
+    return {
+      __esModule: true,
+      default: {
+        prototype: {
+          $set(target, key, value) {
+            target[key] = value
+          }
+        }
+      }
+    }
+  }
+  return originalLoad.call(this, request, parent, isMain)
+}
+
+let modules
+try {
+  modules = {
+    home: require('./home').default,
+    search: require('./search').default,
+    video: require('./video').default,
+    headline: require('./headline').default,
+    record: require('./record').default
+  }
+} finally {
+  Module._load = originalLoad
+}
+
+async function assertRejectsAndClears(label, action, state, loadingKey, params) {
+  state[loadingKey] = false
+
+  const request = action({ state, commit() {} }, params)
+  assert.strictEqual(state[loadingKey], true, `${label} must enable loading before requesting`)
+  await assert.rejects(request, error => error === requestError)
+  assert.strictEqual(state[loadingKey], false, `${label} must clear loading after rejection`)
+}
+
+async function run() {
+  const cases = [
+    ['home/getHomeList', modules.home.actions.getHomeList, modules.home.state, 'newsLoading', { id: 1 }],
+    ['search/getSearchList', modules.search.actions.getSearchList, modules.search.state, 'loading', {}],
+    ['video/getVideoList', modules.video.actions.getVideoList, modules.video.state, 'loading', {}],
+    ['headline/getHeadlineList', modules.headline.actions.getHeadlineList, modules.headline.state, 'loading', {}],
+    ['headline/addHeadline', modules.headline.actions.addHeadline, modules.headline.state, 'loading', {}],
+    ['record/getRecordList', modules.record.actions.getRecordList, modules.record.state, 'loading', { title: '我的收藏' }]
+  ]
+
+  const originalLog = console.log
+  console.log = () => {}
+  try {
+    for (const testCase of cases) {
+      await assertRejectsAndClears(...testCase)
+    }
+  } finally {
+    console.log = originalLog
+  }
+
+  originalLog('loading state error tests passed')
+}
+
+run().catch(error => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/vue-toutiao/src/store/modules/record.js
+++ b/vue-toutiao/src/store/modules/record.js
@@ -31,6 +31,7 @@ const record = {
                         commit('GETRECORDLIST', res.data.list)
                         resolve(res.data.list)
                     }).catch( err => {
+                        state.loading = false
                         reject(err)
                     })
             })

--- a/vue-toutiao/src/store/modules/search.js
+++ b/vue-toutiao/src/store/modules/search.js
@@ -34,6 +34,7 @@ const common = {
                         
                         resolve(res.data.list)
                     }).catch( err => {
+                        state.loading = false
                         reject(err)
                     })
             })

--- a/vue-toutiao/src/store/modules/video.js
+++ b/vue-toutiao/src/store/modules/video.js
@@ -23,6 +23,7 @@ const video = {
                         commit('GETVIDEOLIST', res.data.list)
                         resolve(res.data.list)
                     }).catch( err => {
+                        state.loading = false
                         reject(err)
                     })
             })


### PR DESCRIPTION
## Problem

Several Vuex actions set their page loading indicator before calling the external API, but only cleared it on success. A rejected request could therefore leave Home, Search, Video, Headline, or Record views showing a permanent spinner.

## Changes

- clear each affected loading flag in the request failure path
- preserve the original rejected error and all existing success behavior
- add a table-driven regression test covering six affected actions
- include the regression test in the project's full test command
- document the scoped design and implementation plan

## Validation

- `npm test`
- `NODE_OPTIONS=--openssl-legacy-provider npm run build`
- `git -c core.whitespace=cr-at-eol diff --check`

All checks passed locally.