### PR TITLE
fix: abort unauthorized route navigation

### DIFF
--- a/vue-toutiao/package.json
+++ b/vue-toutiao/package.json
@@ -16,7 +16,8 @@
     "test:article-route": "node src/views/Article/load-article-when-changed.test.js",
     "test:home-scroll": "node src/views/Home/scroll-position.test.js",
     "test:loading-state": "node src/store/modules/loading-state.test.js",
-    "test": "npm run test:ensure-dll && npm run test:storage && npm run test:article-route && npm run test:home-scroll && npm run test:loading-state",
+    "test:router-permission": "node src/router/permission.test.js",
+    "test": "npm run test:ensure-dll && npm run test:storage && npm run test:article-route && npm run test:home-scroll && npm run test:loading-state && npm run test:router-permission",
     "analyze": "cross-env analyz_npm_config_report=true npm run build",
     "analyz": "npm run analyze"
   },

--- a/vue-toutiao/src/router/permission.js
+++ b/vue-toutiao/src/router/permission.js
@@ -7,6 +7,7 @@ router.beforeEach((to, from, next) => {
         if (store.state.user.user.name) { // 是否已经登陆
             next()
         }else{
+            next(false)
             Vue.prototype.$alert('请先登录!')
                 .then( () => {
                     store.state.user.isLogin = true

--- a/vue-toutiao/src/router/permission.test.js
+++ b/vue-toutiao/src/router/permission.test.js
@@ -1,0 +1,87 @@
+'use strict'
+
+process.env.BABEL_ENV = 'test'
+require('babel-register')
+
+const assert = require('assert')
+const Module = require('module')
+
+const store = {
+  state: {
+    user: {
+      user: { name: '' },
+      isLogin: false
+    },
+    app: {
+      pageLoading: false
+    }
+  }
+}
+
+const guards = {}
+const router = {
+  beforeEach(handler) {
+    guards.beforeEach = handler
+  },
+  afterEach(handler) {
+    guards.afterEach = handler
+  }
+}
+
+const Vue = {
+  prototype: {
+    $alert() {
+      return Promise.resolve()
+    }
+  }
+}
+
+const originalLoad = Module._load
+Module._load = function loadWithRouterDependencies(request, parent, isMain) {
+  if (request === '../store') {
+    return { __esModule: true, default: store }
+  }
+  if (request === 'vue') {
+    return { __esModule: true, default: Vue }
+  }
+  if (request === './index') {
+    return { __esModule: true, router }
+  }
+  return originalLoad.call(this, request, parent, isMain)
+}
+
+const originalDocument = global.document
+global.document = { title: '' }
+
+try {
+  require('./permission')
+} finally {
+  Module._load = originalLoad
+  global.document = originalDocument
+}
+
+async function run() {
+  const navigationDecisions = []
+
+  guards.beforeEach(
+    { meta: { login: true } },
+    {},
+    decision => navigationDecisions.push(decision)
+  )
+
+  assert.deepStrictEqual(
+    navigationDecisions,
+    [false],
+    'unauthenticated protected navigation must be aborted immediately'
+  )
+
+  await Promise.resolve()
+  assert.strictEqual(store.state.user.isLogin, true, 'login panel must still open after the alert')
+
+  console.log('router permission tests passed')
+}
+
+run().catch(error => {
+  console.error(error)
+  process.exitCode = 1
+})


### PR DESCRIPTION
## Problem

When a logged-out user opened a route marked with `meta.login`, the navigation guard showed the login prompt but never called `next`. Vue Router therefore left the navigation pending indefinitely.

## Changes

- abort unauthorized protected-route navigation immediately with `next(false)`
- preserve the existing alert and login-panel behavior
- add a regression test that exercises the registered guard and verifies both the abort decision and login-panel flow
- include the new test in the full test command

## Validation

- `npm test`
- `NODE_OPTIONS=--openssl-legacy-provider npm run build`
- `git -c core.whitespace=cr-at-eol diff --check`

All checks passed locally.