### PR TITLE
fix: keep login open after request failure

### DIFF
--- a/vue-toutiao/package.json
+++ b/vue-toutiao/package.json
@@ -17,7 +17,8 @@
     "test:home-scroll": "node src/views/Home/scroll-position.test.js",
     "test:loading-state": "node src/store/modules/loading-state.test.js",
     "test:router-permission": "node src/router/permission.test.js",
-    "test": "npm run test:ensure-dll && npm run test:storage && npm run test:article-route && npm run test:home-scroll && npm run test:loading-state && npm run test:router-permission",
+    "test:login": "node src/components/Login/login.test.js",
+    "test": "npm run test:ensure-dll && npm run test:storage && npm run test:article-route && npm run test:home-scroll && npm run test:loading-state && npm run test:router-permission && npm run test:login",
     "analyze": "cross-env analyz_npm_config_report=true npm run build",
     "analyz": "npm run analyze"
   },

--- a/vue-toutiao/src/components/Login/index.vue
+++ b/vue-toutiao/src/components/Login/index.vue
@@ -48,9 +48,10 @@
                         password: this.password
                     })
                 }catch (e) {
-
+                    return
+                }finally {
+                    this.$hideLoading()
                 }
-                this.$hideLoading()
                 this.$set(this.$store.state.user.footerBarList, 3, {title: '我的', icon: 'account1', path: '/account'})
                 this.$emit('close')
                 // let avatar = require('assets/images/avatar.png')

--- a/vue-toutiao/src/components/Login/login.test.js
+++ b/vue-toutiao/src/components/Login/login.test.js
@@ -1,0 +1,79 @@
+'use strict'
+
+process.env.BABEL_ENV = 'test'
+
+const assert = require('assert')
+const babel = require('babel-core')
+const fs = require('fs')
+const Module = require('module')
+const path = require('path')
+const compiler = require('vue-template-compiler')
+
+function loadLoginComponent() {
+  const filename = path.join(__dirname, 'index.vue')
+  const source = fs.readFileSync(filename, 'utf8')
+  const script = compiler.parseComponent(source).script.content
+  const compiled = babel.transform(script, { filename }).code
+  const componentModule = new Module(filename, module)
+
+  componentModule.filename = filename
+  componentModule.paths = module.paths
+  componentModule._compile(compiled, filename)
+
+  return componentModule.exports.default
+}
+
+async function run() {
+  const login = loadLoginComponent().methods.login
+  const events = []
+  const footerBarList = [
+    { title: '首页', icon: 'home', path: '/home' },
+    { title: '西瓜视频', icon: 'video', path: '/video' },
+    { title: '微头条', icon: 'comment', path: '/headline' },
+    { title: '未登录', icon: 'account1', path: '/account' }
+  ]
+
+  await login.call({
+    username: 'reader',
+    password: '123456',
+    username_msg: '',
+    password_msg: '',
+    $showLoading() {
+      events.push('loading:show')
+    },
+    $hideLoading() {
+      events.push('loading:hide')
+    },
+    $store: {
+      state: { user: { footerBarList } },
+      dispatch() {
+        return Promise.reject(new Error('request failed'))
+      }
+    },
+    $set(target, index, value) {
+      target[index] = value
+      events.push('footer:update')
+    },
+    $emit(event) {
+      events.push(`emit:${event}`)
+    }
+  })
+
+  assert.deepStrictEqual(
+    events,
+    ['loading:show', 'loading:hide'],
+    'a failed login must stop loading without updating the footer or closing the panel'
+  )
+  assert.deepStrictEqual(
+    footerBarList[3],
+    { title: '未登录', icon: 'account1', path: '/account' },
+    'a failed login must preserve the logged-out navigation item'
+  )
+
+  console.log('login failure tests passed')
+}
+
+run().catch(error => {
+  console.error(error)
+  process.exitCode = 1
+})


### PR DESCRIPTION
## Problem

When the login request rejects, the login component currently continues into its success-only UI updates. This closes the login panel and changes the footer to the authenticated state even though authentication failed.

## Changes

- return from the login flow when the store action rejects
- move loading cleanup into `finally` so both success and failure stop the loading indicator
- add a component-level regression test for the failed-request path and include it in the full test suite

## Validation

- `npm test`
- `npm run build`
- `git diff --check` (with the repository's CRLF line endings recognized)
