### PR TITLE
fix: allow pagination retry after request errors

### DIFF
--- a/vue-toutiao/package.json
+++ b/vue-toutiao/package.json
@@ -18,7 +18,8 @@
     "test:loading-state": "node src/store/modules/loading-state.test.js",
     "test:router-permission": "node src/router/permission.test.js",
     "test:login": "node src/components/Login/login.test.js",
-    "test": "npm run test:ensure-dll && npm run test:storage && npm run test:article-route && npm run test:home-scroll && npm run test:loading-state && npm run test:router-permission && npm run test:login",
+    "test:loading-more": "node src/views/loading-more-error.test.js",
+    "test": "npm run test:ensure-dll && npm run test:storage && npm run test:article-route && npm run test:home-scroll && npm run test:loading-state && npm run test:router-permission && npm run test:login && npm run test:loading-more",
     "analyze": "cross-env analyz_npm_config_report=true npm run build",
     "analyz": "npm run analyze"
   },

--- a/vue-toutiao/src/views/Headline/index.vue
+++ b/vue-toutiao/src/views/Headline/index.vue
@@ -66,12 +66,10 @@
         },
         
         methods: {
-            loadingMore () {
-                return new Promise( async (resolve, reject) => {
-                    this.pageindex ++
-                    await this.$store.dispatch('getHeadlineList', { pageindex: this.pageindex })
-                    resolve()
-                })
+            async loadingMore () {
+                const nextPage = this.pageindex + 1
+                await this.$store.dispatch('getHeadlineList', { pageindex: nextPage })
+                this.pageindex = nextPage
             },
             // 点赞
             likeNum (item) {

--- a/vue-toutiao/src/views/Search/body/index.vue
+++ b/vue-toutiao/src/views/Search/body/index.vue
@@ -97,12 +97,16 @@
             removeHistory (keyword) {
                 this.$store.dispatch('removeSearchHistory', keyword)
             },
-            loadingMore () {
-                return new Promise(async (resolve) => {
-                    this.$store.state.search.pageindex++
-                    await this.$store.dispatch('getSearchList', { keyword: this.keyword, pageindex: this.searchPageindex })
-                    resolve()
-                })
+            async loadingMore () {
+                const previousPage = this.$store.state.search.pageindex
+                const nextPage = previousPage + 1
+                this.$store.state.search.pageindex = nextPage
+                try {
+                    await this.$store.dispatch('getSearchList', { keyword: this.keyword, pageindex: nextPage })
+                }catch (error) {
+                    this.$store.state.search.pageindex = previousPage
+                    throw error
+                }
             }
         },
         computed: {

--- a/vue-toutiao/src/views/Video/index.vue
+++ b/vue-toutiao/src/views/Video/index.vue
@@ -59,12 +59,10 @@
         },
         methods: {
             // 加载更多
-            loadingMore () {
-                return new Promise( async (resolve, reject) => {
-                    this.pageindex ++
-                    await this.$store.dispatch('getVideoList', { pageindex: this.pageindex })
-                    resolve()
-                })
+            async loadingMore () {
+                const nextPage = this.pageindex + 1
+                await this.$store.dispatch('getVideoList', { pageindex: nextPage })
+                this.pageindex = nextPage
             },
             // 播放
             play (index, item) {

--- a/vue-toutiao/src/views/loading-more-error.test.js
+++ b/vue-toutiao/src/views/loading-more-error.test.js
@@ -1,0 +1,135 @@
+'use strict'
+
+process.env.BABEL_ENV = 'test'
+
+const assert = require('assert')
+const babel = require('babel-core')
+const fs = require('fs')
+const Module = require('module')
+const path = require('path')
+const compiler = require('vue-template-compiler')
+
+function loadComponent(relativePath) {
+  const filename = path.join(__dirname, relativePath)
+  const source = fs.readFileSync(filename, 'utf8')
+  const script = compiler.parseComponent(source).script.content
+  const compiled = babel.transform(script, { filename }).code
+  const componentModule = new Module(filename, module)
+  const originalLoad = Module._load
+
+  componentModule.filename = filename
+  componentModule.paths = module.paths
+  Module._load = function loadWithComponentDependencies(request, parent, isMain) {
+    if (request === './topBar/index') {
+      return { __esModule: true, default: {} }
+    }
+    return originalLoad.call(this, request, parent, isMain)
+  }
+
+  try {
+    componentModule._compile(compiled, filename)
+  } finally {
+    Module._load = originalLoad
+  }
+
+  return componentModule.exports.default
+}
+
+async function observeSettlement(promise) {
+  let unhandledRejection
+  const onUnhandledRejection = error => {
+    unhandledRejection = error
+  }
+
+  process.on('unhandledRejection', onUnhandledRejection)
+  try {
+    const outcome = await Promise.race([
+      promise.then(
+        value => ({ status: 'resolved', value }),
+        error => ({ status: 'rejected', error })
+      ),
+      new Promise(resolve => setImmediate(() => resolve({ status: 'pending' })))
+    ])
+    await new Promise(resolve => setImmediate(resolve))
+    return { outcome, unhandledRejection }
+  } finally {
+    process.removeListener('unhandledRejection', onUnhandledRejection)
+  }
+}
+
+async function run() {
+  const requestError = new Error('request failed')
+  const video = loadComponent('Video/index.vue')
+  const headline = loadComponent('Headline/index.vue')
+  const search = loadComponent('Search/body/index.vue')
+  const searchState = {
+    keyword: 'news',
+    pageindex: 1,
+    list: [],
+    history: [],
+    loading: false,
+    loadingMore: false,
+    end: false
+  }
+  const cases = [
+    {
+      label: 'video',
+      method: video.methods.loadingMore,
+      context: {
+        pageindex: 1,
+        $store: { dispatch: () => Promise.reject(requestError) }
+      },
+      readPage: context => context.pageindex
+    },
+    {
+      label: 'headline',
+      method: headline.methods.loadingMore,
+      context: {
+        pageindex: 1,
+        $store: { dispatch: () => Promise.reject(requestError) }
+      },
+      readPage: context => context.pageindex
+    },
+    {
+      label: 'search',
+      method: search.methods.loadingMore,
+      context: {
+        keyword: 'news',
+        searchPageindex: 2,
+        $store: {
+          state: { search: searchState },
+          dispatch: () => Promise.reject(requestError)
+        }
+      },
+      readPage: context => context.$store.state.search.pageindex
+    }
+  ]
+
+  for (const testCase of cases) {
+    const result = await observeSettlement(testCase.method.call(testCase.context))
+
+    assert.strictEqual(
+      result.outcome.status,
+      'rejected',
+      `${testCase.label} loading must reject promptly after a request error`
+    )
+    assert.strictEqual(result.outcome.error, requestError)
+    assert.strictEqual(
+      testCase.readPage(testCase.context),
+      1,
+      `${testCase.label} loading must preserve the page number for retry`
+    )
+    assert.strictEqual(
+      result.unhandledRejection,
+      undefined,
+      `${testCase.label} loading must not create an unhandled rejection`
+    )
+  }
+
+  console.log('loading more error tests passed')
+}
+
+run().catch(error => {
+  console.error(error)
+  process.exitCode = 1
+})


### PR DESCRIPTION
## Problem

The video, headline, and search infinite-scroll handlers wrap an `async` executor in `new Promise`. If the Vuex request rejects, that inner rejection never settles the returned Promise. The scroll directive remains locked in its loading state, and the page counter has already advanced, so a retry can skip data.

## Changes

- return real `async` handler Promises so request failures reach the scroll directive
- only advance video and headline page numbers after successful requests
- roll back the search page number when its request fails
- add component-level regression coverage for all three failure paths

## Validation

- `npm test`
- `npm run build`
- `git diff --check` with the repository's CRLF line endings recognized
