### PR TITLE
fix: remove scroll listener on directive unbind

### DIFF
--- a/vue-toutiao/package.json
+++ b/vue-toutiao/package.json
@@ -19,7 +19,8 @@
     "test:router-permission": "node src/router/permission.test.js",
     "test:login": "node src/components/Login/login.test.js",
     "test:loading-more": "node src/views/loading-more-error.test.js",
-    "test": "npm run test:ensure-dll && npm run test:storage && npm run test:article-route && npm run test:home-scroll && npm run test:loading-state && npm run test:router-permission && npm run test:login && npm run test:loading-more",
+    "test:scroll-directive": "node src/directive/scroll.test.js",
+    "test": "npm run test:ensure-dll && npm run test:storage && npm run test:article-route && npm run test:home-scroll && npm run test:loading-state && npm run test:router-permission && npm run test:login && npm run test:loading-more && npm run test:scroll-directive",
     "analyze": "cross-env analyz_npm_config_report=true npm run build",
     "analyz": "npm run analyze"
   },

--- a/vue-toutiao/src/directive/scroll.js
+++ b/vue-toutiao/src/directive/scroll.js
@@ -1,5 +1,6 @@
 import Vue from 'vue'
 
+const scrollHandlers = new WeakMap()
 
 Vue.directive('scroll', {
     inserted: function (el, binding, vnode, oldVnode) {
@@ -7,7 +8,7 @@ Vue.directive('scroll', {
             isLoading = false,
             cb_name = binding.expression,
             cb = vnode.context[cb_name]
-        el.addEventListener('scroll', async () => {
+        const handler = async () => {
             if (w + el.scrollTop + 10 >= el.firstChild.clientHeight && !isLoading) {
                 isLoading = true
                 try {
@@ -17,6 +18,14 @@ Vue.directive('scroll', {
                 }
                 isLoading = false
             }
-        })
+        }
+        scrollHandlers.set(el, handler)
+        el.addEventListener('scroll', handler)
+    },
+    unbind: function (el) {
+        const handler = scrollHandlers.get(el)
+        if (!handler) return
+        el.removeEventListener('scroll', handler)
+        scrollHandlers.delete(el)
     }
 })

--- a/vue-toutiao/src/directive/scroll.test.js
+++ b/vue-toutiao/src/directive/scroll.test.js
@@ -1,0 +1,77 @@
+'use strict'
+
+process.env.BABEL_ENV = 'test'
+require('babel-register')
+
+const assert = require('assert')
+const Module = require('module')
+
+let scrollDirective
+const Vue = {
+  directive(name, definition) {
+    if (name === 'scroll') scrollDirective = definition
+  }
+}
+
+const originalLoad = Module._load
+Module._load = function loadWithDirectiveDependencies(request, parent, isMain) {
+  if (request === 'vue') {
+    return { __esModule: true, default: Vue }
+  }
+  return originalLoad.call(this, request, parent, isMain)
+}
+
+try {
+  require('./scroll')
+} finally {
+  Module._load = originalLoad
+}
+
+function run() {
+  const listeners = new Map()
+  const element = {
+    offsetHeight: 100,
+    scrollTop: 0,
+    firstChild: { clientHeight: 500 },
+    addEventListener(type, handler) {
+      listeners.set(type, handler)
+    },
+    removeEventListener(type, handler) {
+      if (listeners.get(type) === handler) listeners.delete(type)
+    }
+  }
+  const context = {
+    loadingMore() {
+      return Promise.resolve()
+    }
+  }
+
+  scrollDirective.inserted(
+    element,
+    { expression: 'loadingMore' },
+    { context }
+  )
+  assert.strictEqual(
+    listeners.has('scroll'),
+    true,
+    'the directive must register its scroll listener when inserted'
+  )
+  if (typeof scrollDirective.unbind === 'function') {
+    scrollDirective.unbind(element)
+  }
+
+  assert.strictEqual(
+    listeners.has('scroll'),
+    false,
+    'the scroll listener must be removed when the directive is unbound'
+  )
+
+  console.log('scroll directive cleanup tests passed')
+}
+
+try {
+  run()
+} catch (error) {
+  console.error(error)
+  process.exitCode = 1
+}


### PR DESCRIPTION
## Problem
The custom `v-scroll` directive attaches a scroll listener but never removes it when Vue unbinds the directive. Navigating among infinite-scroll views can retain stale elements/component callbacks and allow obsolete handlers to run.

## Changes
- retain each element's listener in a `WeakMap`
- remove the exact listener and its map entry during `unbind`
- add a lifecycle regression test and include it in the full suite

## Validation
- `npm test`
- `npm run build`
- `git diff --check` with CRLF recognized